### PR TITLE
note alternative for digital triggers in annotations 

### DIFF
--- a/trc2bids/run_annotated_aECoG_TRC2bids_batch.m
+++ b/trc2bids/run_annotated_aECoG_TRC2bids_batch.m
@@ -124,7 +124,7 @@ for pat = 1:size(pats,1)
     
     if contains(pats(pat).name,'PAT')
         n = 1;
-        cfg.pathname = [fullfile(dbdir,pats(pat).name),'/'];
+        cfg.pathname = [fullfile(cfg.proj_dirinput,pats(pat).name),'/'];
         
         files = dir(cfg.pathname);
         

--- a/trc2bids/utils/annotatedTRC2bids.m
+++ b/trc2bids/utils/annotatedTRC2bids.m
@@ -55,7 +55,7 @@ try
     % obtain information from the header of the trc-file
     [header,data,data_time,trigger,annots] = read_TRC_HDR_DATA_TRIGS_ANNOTS(filename);
     
-    if(isempty(header) || isempty(data) || isempty(data_time) || isempty(trigger) || isempty(annots))
+    if(isempty(header) || isempty(data) || isempty(data_time) || isempty(trigger) && isempty(annots))
         output = [];
         msg = 'TRC reading failed';
         error('TRC reading failed')  ;

--- a/trc2bids/utils/extract_metadata_from_annotations.m
+++ b/trc2bids/utils/extract_metadata_from_annotations.m
@@ -51,12 +51,20 @@ try
     end
     metadata.ch2use_included = single_annotation(annots,'Included',ch);
     
-    % good data segments
+    %% good data segments
     
     %Codes for start and stop of good segments
     BEG_GS = 222;
     END_GS = 223;
     
+    %notes as substitute triggers
+    notetrig=look_for_good_segment_notes(annots,sfreq,num2str(BEG_GS),num2str(END_GS));
+    trigsubs=zeros(2,0)
+    for j=1:numel(notetrig)
+        trigsubs=[trigsubs,[notetrig{j}.pos.*sfreq;BEG_GS,END_GS]];
+    end
+    trigger=[trigger, trigsubs];   
+
     trig_pos  = trigger(1,:);
     trig_v    = trigger(2,:);
 

--- a/trc2bids/utils/look_for_good_segment_notes.m
+++ b/trc2bids/utils/look_for_good_segment_notes.m
@@ -1,0 +1,41 @@
+
+function triggersub = look_for_good_segment_notes(annots,sfreq,segstarts,segstops)
+
+if ~iscell(segstarts),segstarts={segstarts};end
+if ~iscell(segstops),segstops={segstops};end
+
+start_seg =[];
+end_seg = [];
+for i=numel(segstarts)
+    Seg_Start = segstarts{i};
+    Seg_Stop = segstops{i};
+    
+    start_seg = [start_seg;find(startsWith(annots(:,2),Seg_Start))];
+    end_seg   = [end_seg;find(startsWith(annots(:,2),Seg_Stop))];
+
+
+    if(length(start_seg) ~= length(end_seg))
+        error('trigger substitute notes: starts and ends did no match')
+end
+end
+
+triggersub = cell(size(start_seg));
+
+for i = 1:numel(start_seg)
+    
+    segment          = struct;
+    matched_end = find(contains(annots(:,2),Seg_Stop));
+    
+    if(isempty(matched_end))
+        error('start and stop %s does not match',annots{start_seg(i),2});
+    end
+    if(length(matched_end)>1)
+        
+        matched_end       = matched_end((matched_end-start_seg(i))>0);
+        [val,idx_closest] = min(matched_end);
+        matched_end       = matched_end(idx_closest);%take the closest in time
+    end
+    
+    segment.pos          = [(annots{start_seg(i),1})/sfreq annots{matched_end,1}/sfreq];
+    triggersub{i} = segment;
+end


### PR DESCRIPTION
Notes can now also be used instead of digital triggers to mark good segments in trc files. Notes with '222' and '223' will be appended to the trigger array before parsing and validating the triggers.