### PR TITLE
feat(trc2bids): automatically update group permissions to write

### DIFF
--- a/trc2bids/utils/convertTRC2brainvision.m
+++ b/trc2bids/utils/convertTRC2brainvision.m
@@ -29,4 +29,13 @@ temp.ieeg.writesidecar = 'no';
 % write .vhdr, .eeg, .vmrk
 data2bids(temp, data2write)
 
+% fix group permissions
+newFiles=replace(temp.outputfile,'vhdr','*');
+try
+    fileattrib(newFiles,'+w','g')
+    %disp('vhdr,eeg,vmrk file permissions in output directory set for group')
+catch
+    warning('Could not automatically set group permissions. /n Check permissions for files %s', newFiles)
+end
+
 end

--- a/trc2bids/utils/mydirMaker.m
+++ b/trc2bids/utils/mydirMaker.m
@@ -4,4 +4,12 @@ if exist(dirname, 'dir')
     warning('%s exist already',dirname)
 else
     mkdir(dirname)
+    
+    try
+    fileattrib(dirname,'+w','g')
+    %disp('directory permissions in output directory set for group')
+    catch
+    warning('Could not automatically set group permissions. /n Check permissions for directory %s', dirname)
+    end
+    
 end

--- a/trc2bids/utils/write_json.m
+++ b/trc2bids/utils/write_json.m
@@ -14,3 +14,9 @@ else
     fwrite(fid, str);
     fclose(fid);
 end
+try
+    fileattrib(filename,'+w','g')
+    %disp('json write permissions in output directory set for group')
+catch
+    warning('Could not automatically set group permissions. /n Check permissions for file %s', filename)
+end

--- a/trc2bids/utils/write_tsv.m
+++ b/trc2bids/utils/write_tsv.m
@@ -4,5 +4,10 @@
 function write_tsv(filename, tsv)
 ft_info('writing %s\n', filename);
 writetable(tsv, filename, 'Delimiter', 'tab', 'FileType', 'text');
-
+try
+    fileattrib(filename,'+w','g')
+    %disp('tsv write permissions in output directory set for group')
+catch
+    warning('Could not automatically set group permissions. /n Check permissions for file %s', filename)
+end
 %%%%%


### PR DESCRIPTION
dir maker, json writer, tsv writer, and trc2brainvision all add file attribute write (+w) to the group users (g)

yields warning if it does not work and need manual permission check