### PR TITLE
Changed selecting a channel in channel list

### DIFF
--- a/micromed_utils/parse_annotation.m
+++ b/micromed_utils/parse_annotation.m
@@ -49,7 +49,7 @@ for i=2:numel(C)
             curr_str = deblank(curr_str);
             curr_str_flipped = deblank(curr_str(end:-1:1));
             curr_str = curr_str_flipped(end:-1:1);
-            ch2use(contains(chs,curr_str,'IgnoreCase',true))=1;
+            ch2use = ch2use | strcmpi(chs,curr_str);
         end
 
     else


### PR DESCRIPTION
Changed to 'contains(all_channels, channel)' to 'strcmpi(all_channels, channel)' when creating  boolean logic to select channel in all_channels variable.